### PR TITLE
Add docstrings throughout codebase

### DIFF
--- a/custom_components/vicente_energy/__init__.py
+++ b/custom_components/vicente_energy/__init__.py
@@ -1,4 +1,6 @@
 
+"""Home Assistant entrypoint for the Vicente Energy integration."""
+
 import logging
 from datetime import timedelta
 
@@ -180,7 +182,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 class VicenteEnergyCoordinator(DataUpdateCoordinator):
+    """Coordinator to publish calculated Vicente Energy values."""
+
     def __init__(self, hass, sensors, location_name, solar_forecast, ev_charger):
+        """Initialize the coordinator with entity IDs and configuration."""
         self.hass = hass
         self.sensors = sensors
         self.location_name = location_name
@@ -195,6 +200,7 @@ class VicenteEnergyCoordinator(DataUpdateCoordinator):
         )
 
     async def _async_update_data(self):
+        """Refresh calculated sensor values."""
         calculated_values = {
             "solar_power": 0,
             "battery_soc": 0,

--- a/custom_components/vicente_energy/charge_estimator.py
+++ b/custom_components/vicente_energy/charge_estimator.py
@@ -1,9 +1,14 @@
+"""Charging power and budget estimation utilities."""
+
 from .const import CONF_SESSION_LEARNING_ALPHA
 from .models import Forecasts, Signals
 
 
 class ChargeEstimator:
+    """Estimate charging budgets and power levels."""
+
     def __init__(self, params: dict, state_manager):
+        """Store configuration parameters and the state manager."""
         self._params = params
         self._state_manager = state_manager
 

--- a/custom_components/vicente_energy/config_entries.py
+++ b/custom_components/vicente_energy/config_entries.py
@@ -1,11 +1,15 @@
 """Stub for Home Assistant config entries."""
 
 class ConfigFlow:
+    """Simple stub replacement for HA ConfigFlow used in tests."""
+
     # stub init
     def __init_subclass__(cls, *args, **kwargs):
+        """Ignore subclass arguments."""
         super().__init_subclass__()
 
     def async_show_form(self, step_id, data_schema):
+        """Return a fake form result structure."""
         return {
             "type": "form",
             "step_id": step_id,
@@ -13,6 +17,7 @@ class ConfigFlow:
         }
 
     def async_create_entry(self, title, data):
+        """Return a fake entry result structure."""
         return {
             "type": "create_entry",
             "title": title,

--- a/custom_components/vicente_energy/config_flow.py
+++ b/custom_components/vicente_energy/config_flow.py
@@ -1,3 +1,5 @@
+"""Configuration and options flow handlers for Vicente Energy."""
+
 import logging
 import voluptuous as vol
 
@@ -44,6 +46,7 @@ class VicenteEnergyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.async_step_user(user_input=import_config)
 
     async def async_step_user(self, user_input=None) -> FlowResult:
+        """Handle the initial step of the config flow."""
         if user_input is not None:
             # Map friendly names back to internal domain names
             reverse_name_map = self.hass.data["vicente_energy_reverse_map"]
@@ -136,6 +139,7 @@ class VicenteEnergyOptionsFlow(config_entries.OptionsFlow):
         self.reverse_name_map = {}
 
     async def async_step_init(self, user_input=None):
+        """Handle the first step of the options flow."""
         if user_input is not None:
             # Only remap fields corresponding to service types
             service_keys = {stype.value for stype in ServiceType}
@@ -270,6 +274,7 @@ class VicenteEnergyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.async_step_user(user_input=import_config)
 
     async def async_step_user(self, user_input=None) -> FlowResult:
+        """Process user step in duplicated flow block."""
         if user_input is not None:
             # Map friendly names back to internal domain names
             reverse_name_map = self.hass.data["vicente_energy_reverse_map"]
@@ -362,6 +367,7 @@ class VicenteEnergyOptionsFlow(config_entries.OptionsFlow):
         self.reverse_name_map = {}
 
     async def async_step_init(self, user_input=None):
+        """Handle the first step of the options flow."""
         if user_input is not None:
             # Only remap fields corresponding to service types
             service_keys = {stype.value for stype in ServiceType}

--- a/custom_components/vicente_energy/const.py
+++ b/custom_components/vicente_energy/const.py
@@ -1,3 +1,5 @@
+"""Constants for the Vicente Energy integration."""
+
 DOMAIN = "vicente_energy"
 
 CONF_SOLAR_POWER_ENTITY = "solar_power_entity"

--- a/custom_components/vicente_energy/energy_coordinator.py
+++ b/custom_components/vicente_energy/energy_coordinator.py
@@ -1,10 +1,17 @@
+"""Utility helpers for aggregating energy statistics."""
+
+
 class EnergyCoordinator:
+    """Coordinate data between battery and solar services."""
+
     def __init__(self, battery_service, solar_service, hass):
+        """Store service references and Home Assistant handle."""
         self.battery_service = battery_service
         self.solar_service = solar_service
         self.hass = hass
 
     def get_home_load_today(self):
+        """Return today's calculated home load."""
         battery_charge_today = self.battery_service.get_battery_charge_today()
         battery_discharge_today = self.battery_service.get_battery_discharge_today()
         grid_import_today = self.battery_service.get_grid_import_today()

--- a/custom_components/vicente_energy/forecast_accuracy_tracker.py
+++ b/custom_components/vicente_energy/forecast_accuracy_tracker.py
@@ -1,12 +1,18 @@
+"""Track forecast accuracy and update stored bias values."""
+
 from .state_manager import StateManager
 
 
 class ForecastAccuracyTracker:
+    """Compute running forecast error and update bias."""
+
     def __init__(self, state_manager: StateManager, alpha: float, state: StateManager = None):
+        """Initialize with state storage and learning rate."""
         self._state = state if state is not None else state_manager
         self._alpha = alpha
 
     def update_solar(self, forecast_kwh: float, actual_kwh: float):
+        """Update solar bias based on forecast vs actual kWh."""
         if forecast_kwh == 0:
             return
         error = (actual_kwh - forecast_kwh) / forecast_kwh
@@ -14,6 +20,7 @@ class ForecastAccuracyTracker:
         self._state.update_solar_bias(new_bias)
 
     def update_load(self, forecast_kwh: float, actual_kwh: float):
+        """Update load bias based on forecast vs actual kWh."""
         if forecast_kwh == 0:
             return
         error = (actual_kwh - forecast_kwh) / forecast_kwh

--- a/custom_components/vicente_energy/input_collector.py
+++ b/custom_components/vicente_energy/input_collector.py
@@ -1,3 +1,5 @@
+"""Gather raw sensor signals for Vicente Energy calculations."""
+
 from homeassistant.core import HomeAssistant
 
 from .models import Signals
@@ -5,6 +7,8 @@ from .services.service_manager import ServiceManager
 
 
 class InputCollector:
+    """Collect sensor inputs and optional external service data."""
+
     def __init__(self, hass: HomeAssistant, *args,
                  solar_power_entity: str = None,
                  solar_forecast_entities: list = None,
@@ -18,6 +22,10 @@ class InputCollector:
                  battery_entity: str = None,
                  load_entity: str = None,
                  service_manager: ServiceManager = None):
+        """Initialize with entity IDs and optional service manager.
+
+        Legacy positional arguments are supported for backwards compatibility.
+        """
         # Legacy positional args mapping:
         if len(args) >= 5:
             # Map first 5 positional args to entity IDs
@@ -46,6 +54,7 @@ class InputCollector:
         self.service_manager = service_manager
 
     def get_signals(self) -> Signals:
+        """Return current Signals dataclass populated from sensors."""
         # Solar power
         sp = self.hass.states.get(self._solar_power_entity) if self._solar_power_entity else None
         solar_power = float(sp.state) if sp and hasattr(sp, "state") else 0.0

--- a/custom_components/vicente_energy/load_forecaster.py
+++ b/custom_components/vicente_energy/load_forecaster.py
@@ -1,16 +1,22 @@
+"""Simple load forecasting based on recent history."""
+
 from collections import deque
 
 from .const import CONF_HOUSE_LOAD_ENTITY
 
 
 class LoadForecaster:
+    """Forecast house load using a rolling history window."""
+
     def __init__(self, hass, config, state_manager):
+        """Initialize with Home Assistant handle and state manager."""
         self.hass = hass
         self.entity_id = config.get(CONF_HOUSE_LOAD_ENTITY)
         self.state = state_manager
         self.history = deque(maxlen=24)  # Stores last 24 hourly values
 
     def update_history(self, actual_value):
+        """Append the latest measured value to the history buffer."""
         if actual_value is not None:
             try:
                 val = float(actual_value)
@@ -19,6 +25,7 @@ class LoadForecaster:
                 pass
 
     def get_raw_forecast(self):
+        """Return the last 24 readings or zero if no history."""
         # If no history, predict zero for 24 hours
         if len(self.history) == 0:
             return [0.0] * 24
@@ -31,6 +38,7 @@ class LoadForecaster:
             return values[-24:]
 
     def get_corrected_forecast(self):
+        """Apply stored bias to the raw forecast."""
         raw = self.get_raw_forecast()
         bias = self.state.get_load_bias()
         return [max(val * (1 + bias), 0.0) for val in raw]

--- a/custom_components/vicente_energy/models.py
+++ b/custom_components/vicente_energy/models.py
@@ -1,10 +1,13 @@
 
+"""Dataclass models used throughout the Vicente Energy integration."""
+
 from dataclasses import dataclass
 from typing import List
 
 
 @dataclass
 class Signals:
+    """Snapshot of sensor inputs used for calculations."""
     solar_power_w: float
     battery_soc_pct: float
     house_load_total_w: float
@@ -13,15 +16,18 @@ class Signals:
 
 @dataclass
 class Forecasts:
+    """Hourly solar and load forecast collections."""
     solar_24h_kwh: List[float]
     load_24h_kwh: List[float]
 
 @dataclass
 class SessionEstimates:
+    """Estimated values for a potential charging session."""
     kwh_estimated: float
     soc_end_pct: float
     available_after_kwh: float
 
 @dataclass
 class SessionActuals:
+    """Actual values recorded from a finished session."""
     kwh_used: float

--- a/custom_components/vicente_energy/sensor.py
+++ b/custom_components/vicente_energy/sensor.py
@@ -1,3 +1,4 @@
+"""Sensor entity implementations for Vicente Energy."""
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import ENERGY_KILO_WATT_HOUR, POWER_KILO_WATT
@@ -7,6 +8,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 DOMAIN = "vicente_energy"
 
 async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up Vicente Energy sensor entities from a config entry."""
     data = hass.data[DOMAIN][entry.entry_id]
     sensors = [
         Budget24hSensor(data["hourly_coordinator"]),
@@ -30,6 +32,7 @@ class LocationNameSensor(SensorEntity):
     """Sensor to expose the configured location name."""
 
     def __init__(self, entry_id, location_name):
+        """Initialize the location name sensor."""
         self._attr_name = "Vicente Energy Location Name"
         self._entry_id = entry_id
         self._location_name = location_name or ""
@@ -41,6 +44,7 @@ class LocationNameSensor(SensorEntity):
 
     @property
     def state(self):
+        """Return the configured location name."""
         return self._location_name
 
 
@@ -49,78 +53,102 @@ class LocationNameSensor(SensorEntity):
         self._location_name = name or ""
 
 class Budget24hSensor(CoordinatorEntity):
+    """Sensor showing the 24‑hour charging budget."""
     def __init__(self, coordinator):
+        """Initialize with the hourly coordinator."""
         super().__init__(coordinator)
         self._attr_name = "Vicente Energy 24h Budget"
         self._attr_unit_of_measurement = ENERGY_KILO_WATT_HOUR
 
     @property
     def state(self):
+        """Return the rounded 24‑hour budget."""
         return round(self.coordinator.data.get("budget_24h_kwh", 0.0), 3)
 
     @property
     def unique_id(self):
+        """Return a unique identifier for the sensor."""
         # Use the coordinator's name (which is typically the entry_id or alias) to form a stable unique_id
         return f"{getattr(self.coordinator, 'name', 'vicente_energy')}_budget_24h_kwh"
 
 class PowerLevelSensor(CoordinatorEntity):
+    """Sensor showing current charging power level."""
     def __init__(self, coordinator):
+        """Initialize with the minute coordinator."""
         super().__init__(coordinator)
         self._attr_name = "Vicente Energy Power Level"
         self._attr_unit_of_measurement = POWER_KILO_WATT
 
     @property
     def state(self):
+        """Return the rounded current power level."""
         return round(self.coordinator.data.get("power_level_kw", 0.0), 3)
 
     @property
     def unique_id(self):
+        """Return a unique identifier for the sensor."""
         return f"{getattr(self.coordinator, 'name', 'vicente_energy')}_power_level_kw"
 
 class SessionStartTimeSensor(CoordinatorEntity):
+    """Sensor showing when the current charging session began."""
+
     def __init__(self, session):
+        """Initialize sensor with the session manager."""
         self._session = session
         self._attr_name = "Vicente Energy Session Start Time"
 
     @property
     def state(self):
+        """Return the ISO formatted session start time."""
         ts = self._session.session_start_time
         return ts.isoformat() if ts else None
 
 class SessionDurationSensor(CoordinatorEntity):
+    """Sensor showing the duration of the current session."""
     def __init__(self, session):
+        """Initialize sensor with the session manager."""
         self._session = session
         self._attr_name = "Vicente Energy Session Duration"
 
     @property
     def state(self):
+        """Return the duration of the charging session in minutes."""
         return int(self._session.session_duration.total_seconds() / 60) if self._session.session_duration else 0
 
 class SessionEnergyUsedSensor(CoordinatorEntity):
+    """Sensor showing energy used in the current session."""
     def __init__(self, session):
+        """Initialize sensor with the session manager."""
         self._session = session
         self._attr_name = "Vicente Energy Session kWh Used"
         self._attr_unit_of_measurement = ENERGY_KILO_WATT_HOUR
 
     @property
     def state(self):
+        """Return energy used so far in the session."""
         return round(self._session.session_kwh_used, 3)
 
 class AvailableAfterSensor(CoordinatorEntity):
+    """Sensor for kWh available after session completion."""
     def __init__(self, session):
+        """Initialize sensor with the session manager."""
         self._session = session
         self._attr_name = "Vicente Energy kWh Available After"
         self._attr_unit_of_measurement = ENERGY_KILO_WATT_HOUR
 
     @property
     def state(self):
+        """Return forecasted battery energy after session completes."""
         return round(self._session.session_available_after, 3)
 
 class ChargeStateSensor(CoordinatorEntity):
+    """Sensor reflecting the charging session state."""
     def __init__(self, session):
+        """Initialize sensor with the session manager."""
         self._session = session
         self._attr_name = "Vicente Energy Charge State"
 
     @property
     def state(self):
+        """Return current charge state string."""
         return self._session.charge_state

--- a/custom_components/vicente_energy/sensor_entities.py
+++ b/custom_components/vicente_energy/sensor_entities.py
@@ -1,41 +1,56 @@
+"""Lightweight sensor entities for coordinator values."""
+
 from homeassistant.components.sensor import SensorEntity
 
 from .const import DOMAIN
 
 
 class Budget24hSensor(SensorEntity):
+    """Expose the 24‑hour energy budget from the coordinator."""
+
     def __init__(self, coordinator):
+        """Initialize with the hourly coordinator."""
         self.coordinator = coordinator
 
     @property
     def name(self):
+        """Return the name of the sensor."""
         return "Vicente 24h Budget"
 
     @property
     def unique_id(self):
+        """Return a unique identifier for this sensor."""
         return f"{self.coordinator.name}_budget_24h_kwh"
 
     @property
     def state(self):
+        """Return the budget value from the coordinator."""
         return self.coordinator.data.get("budget_24h_kwh")
 
 class PowerLevelSensor(SensorEntity):
+    """Expose the instantaneous power level from the coordinator."""
+
     def __init__(self, coordinator):
+        """Initialize with the minute coordinator."""
         self.coordinator = coordinator
 
     @property
     def name(self):
+        """Return the name of the sensor."""
         return "Vicente Power Level"
 
     @property
     def unique_id(self):
+        """Return a unique identifier for this sensor."""
         return f"{self.coordinator.name}_power_level_kw"
 
     @property
     def state(self):
+        """Return the power level value from the coordinator."""
         return self.coordinator.data.get("power_level_kw")
 
 async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up Vicente Energy sensors via config entry."""
     hourly_coordinator = hass.data[DOMAIN][entry.entry_id]["hourly_coordinator"]
     minute_coordinator = hass.data[DOMAIN][entry.entry_id]["minute_coordinator"]
 

--- a/custom_components/vicente_energy/services.py
+++ b/custom_components/vicente_energy/services.py
@@ -1,6 +1,11 @@
 
+"""Home Assistant service registrations for Vicente Energy."""
+
+
 async def async_register_services(hass, domain, session_manager, state_manager):
+    """Register helper services for testing and maintenance."""
     async def handle_set_power(call):
+        """Set charger power level using the session manager."""
         power_kw = call.data.get("power_level_kw")
         if power_kw is not None:
             session_manager.set_power_level(power_kw)
@@ -8,6 +13,7 @@ async def async_register_services(hass, domain, session_manager, state_manager):
             await hass.helpers.entity_component.async_update_entity(f"sensor.{domain}_power_level")
 
     async def handle_reset_history(call):
+        """Clear stored biases and history."""
         # Reset all bias and history data
         state_manager.data["solar_bias"] = 0.0
         state_manager.data["load_bias"] = 0.0

--- a/custom_components/vicente_energy/services/__init__.py
+++ b/custom_components/vicente_energy/services/__init__.py
@@ -1,4 +1,6 @@
 
+"""Expose available service classes and service type mappings."""
+
 # Explicitly import service classes for easy external access
 
 from enum import StrEnum, auto
@@ -24,6 +26,7 @@ from .services.wallbox import WallboxEVChargerService
 
 
 class ServiceType(StrEnum):
+    """Enumeration of supported service categories."""
     EV_CHARGER_SERVICE = auto()
     BATTERY_SERVICE = auto()
     SOLAR_SERVICE = auto()

--- a/custom_components/vicente_energy/services/battery_service.py
+++ b/custom_components/vicente_energy/services/battery_service.py
@@ -1,10 +1,15 @@
+"""Abstract battery storage service."""
+
 from homeassistant.core import HomeAssistant
 
 from .service import VEEntityStateChangeHandler, VEService
 
 
 class BatteryService(VEService):
+    """Base class for battery system integrations."""
+
     def __init__(self, hass: HomeAssistant, entity_handlers: dict[str, VEEntityStateChangeHandler]) -> None:
+        """Initialize default battery state."""
         self._storage_capacity_kwh: float = 0.0
         self._battery_soc: float = 0.0  # 0–100
         self._storage_power_kw: float = 0.0
@@ -14,25 +19,33 @@ class BatteryService(VEService):
         super().__init__(hass, entity_handlers)
 
     async def get_battery_soc(self) -> float:
+        """Return current battery state of charge percentage."""
         return self._battery_soc
 
     async def get_storage_energy_kwh(self) -> float:
+        """Return stored energy based on capacity and SOC."""
         return self._storage_capacity_kwh * (self._battery_soc / 100.0)
 
     async def get_today_charge_kwh(self) -> float:
+        """Return energy charged today in kWh."""
         return self._today_charge_kwh
 
     async def get_today_discharge_kwh(self) -> float:
+        """Return energy discharged today in kWh."""
         return self._today_discharge_kwh
 
     async def get_storage_capacity_kwh(self) -> float:
+        """Return configured storage capacity in kWh."""
         return self._storage_capacity_kwh
 
     async def set_storage_capacity_kwh(self, capacity_kwh: float) -> None:
+        """Update the battery capacity setting."""
         self._storage_capacity_kwh = capacity_kwh
 
     async def get_storage_power_kw(self) -> float:
+        """Return current battery charging/discharging power."""
         return self._storage_power_kw
 
     async def set_storage_power_kw(self, power_kw: float) -> None:
+        """Set the instantaneous power flow for the battery."""
         self._storage_power_kw = power_kw

--- a/custom_components/vicente_energy/services/default.py
+++ b/custom_components/vicente_energy/services/default.py
@@ -1,3 +1,5 @@
+"""Fallback service implementations used when no real service is configured."""
+
 from typing import Optional
 
 from homeassistant.core import HomeAssistant
@@ -7,6 +9,8 @@ from .solar_service import SolarService
 
 
 class DefaultChargerService(EVChargerService):
+    """Simple charger service that stores power values locally."""
+
     def __init__(self, hass: Optional[HomeAssistant]) -> None:
         super().__init__(hass, None)
 
@@ -17,14 +21,20 @@ class DefaultChargerService(EVChargerService):
         self._charging_power_kw = power_kw
 
 class DefaultBatteryService(BatteryService):
+    """Battery service with no external API."""
+
     def __init__(self, hass: Optional[HomeAssistant]) -> None:
         super().__init__(hass, None)
 
 class DefaultSolarService(SolarService):
+    """Solar production service returning zeros."""
+
     def __init__(self, hass: Optional[HomeAssistant]) -> None:
         super().__init__(hass, None)
 
 class DefaultGridService(GridService):
+    """Basic grid service storing latest readings only."""
+
     def __init__(self, hass: Optional[HomeAssistant]) -> None:
         super().__init__(hass, None)
 

--- a/custom_components/vicente_energy/services/ev_charger_service.py
+++ b/custom_components/vicente_energy/services/ev_charger_service.py
@@ -1,3 +1,5 @@
+"""Base classes and helpers for EV charger integrations."""
+
 from abc import abstractmethod
 from enum import StrEnum
 from typing import Optional
@@ -27,7 +29,10 @@ def convert_amps_to_kw(power_a: float, voltage: int = DEFAULT_CHARGER_VOLTAGE) -
     return (power_a * voltage)/ 1000
 
 class EVChargerService(VEService):
+    """Common functionality for EV charger services."""
+
     def __init__(self, hass: Optional[HomeAssistant], entity_handlers: dict[str, VEEntityStateChangeHandler]) -> None:
+        """Initialize default charger state."""
         self._charger_state = EVChargerState.CHARGER_UNKNOWN
         self._voltage: int = DEFAULT_CHARGER_VOLTAGE
         self._max_charging_power_amps: int = 0

--- a/custom_components/vicente_energy/services/forecast_service.py
+++ b/custom_components/vicente_energy/services/forecast_service.py
@@ -1,8 +1,13 @@
+"""Base class for solar production forecast services."""
+
 from .service import VEEntityStateChangeHandler, VEService
 
 
 class ForecastService(VEService):
+    """Provide solar production forecasts."""
+
     def __init__(self, hass, entity_handlers: dict[str, VEEntityStateChangeHandler]):
+        """Initialize forecast storage attributes."""
         self._today_production_kwh: float = 0.0
         self._tomorrow_production_kwh: float = 0.0
         self._now_production_kw: float = 0.0

--- a/custom_components/vicente_energy/services/forecast_solar.py
+++ b/custom_components/vicente_energy/services/forecast_solar.py
@@ -1,3 +1,5 @@
+"""Service wrapper for the Forecast.Solar integration."""
+
 import asyncio
 import logging
 
@@ -6,6 +8,8 @@ from .forecast_service import ForecastService
 _LOGGER = logging.getLogger(__name__)
 
 class ForecastSolarService(ForecastService):
+    """Handle Forecast.Solar sensor values."""
+
     def __init__(self, hass: Optional[HomeAssistant]) -> None:
         self._today_hourly_production_kwh: List[float] = [0.0] * 24
         self._tomorrow_hourly_production_kwh: List[float] = [0.0] * 24

--- a/custom_components/vicente_energy/services/franklin.py
+++ b/custom_components/vicente_energy/services/franklin.py
@@ -1,3 +1,5 @@
+"""Service implementations for FranklinWH devices."""
+
 import logging
 from typing import Optional
 
@@ -9,6 +11,8 @@ from .solar_service import SolarService
 _LOGGER = logging.getLogger(__name__)
 
 class FranklinBatteryService(BatteryService):
+    """Battery service for FranklinWH systems."""
+
     def __init__(self, hass: Optional[HomeAssistant]) -> None:
         # Define handlers
         handlers: dict[str, VEEntityStateChangeHandler] = {
@@ -61,6 +65,8 @@ class FranklinBatteryService(BatteryService):
         return True
 
 class FranklinSolarService(SolarService):
+    """Solar production service for FranklinWH inverters."""
+
     def __init__(self, hass: Optional[HomeAssistant]) -> None:
         # Define handlers
         handlers: dict[str, VEEntityStateChangeHandler] = {
@@ -98,6 +104,8 @@ class FranklinSolarService(SolarService):
         return True
 
 class FranklinGridService(GridService):
+    """Grid data service for FranklinWH gateway."""
+
     def __init__(self, hass: Optional[HomeAssistant]) -> None:
         # Define handlers
         handlers: dict[str, VEEntityStateChangeHandler] = {

--- a/custom_components/vicente_energy/services/grid_service.py
+++ b/custom_components/vicente_energy/services/grid_service.py
@@ -1,8 +1,13 @@
+"""Base class for grid energy service providers."""
+
 from .service import VEEntityStateChangeHandler, VEService
 
 
 class GridService(VEService):
+    """Represent grid import/export measurements."""
+
     def __init__(self, hass, entity_handlers: dict[str, VEEntityStateChangeHandler]):
+        """Initialize default state values."""
         self._today_export_kwh: float = 0.0
         self._today_import_kwh: float = 0.0
         self._now_home_load_kw: float = 0.0

--- a/custom_components/vicente_energy/services/service_manager.py
+++ b/custom_components/vicente_energy/services/service_manager.py
@@ -1,3 +1,5 @@
+"""Create and manage external service instances."""
+
 import logging
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/vicente_energy/services/solar_service.py
+++ b/custom_components/vicente_energy/services/solar_service.py
@@ -1,8 +1,13 @@
+"""Abstract solar production service base class."""
+
 from .service import VEEntityStateChangeHandler, VEService
 
 
 class SolarService(VEService):
+    """Base class for solar production providers."""
+
     def __init__(self, hass, entity_handlers: dict[str, VEEntityStateChangeHandler]):
+        """Initialize default production values."""
         self._now_production_kw: float = 0.0
         self._today_production_kwh: float = 0.0
 

--- a/custom_components/vicente_energy/services/solcast.py
+++ b/custom_components/vicente_energy/services/solcast.py
@@ -1,3 +1,5 @@
+"""Service wrapper for Solcast solar forecast sensors."""
+
 import logging
 
 from .forecast_service import ForecastService
@@ -5,6 +7,8 @@ from .forecast_service import ForecastService
 _LOGGER = logging.getLogger(__name__)
 
 class SolcastService(ForecastService):
+    """Use Solcast sensors to provide forecast data."""
+
     def __init__(self, hass: Optional[HomeAssistant]) -> None:
         self._today_hourly_production_kwh: Optional[List[float]] = None
         self._tomorrow_hourly_production_kwh: Optional[List[float]] = None

--- a/custom_components/vicente_energy/services/wallbox.py
+++ b/custom_components/vicente_energy/services/wallbox.py
@@ -1,3 +1,5 @@
+"""Wallbox EV charger service implementation."""
+
 import logging
 from typing import Optional
 
@@ -25,6 +27,8 @@ WALLBOX_STATE_MAP = {
 _LOGGER = logging.getLogger(__name__)
 
 class WallboxEVChargerService(EVChargerService):
+    """Interface with a Wallbox charger via HA entities."""
+
     def __init__(self, hass: Optional[HomeAssistant]) -> None:
         self._location: Optional[str] = None
 

--- a/custom_components/vicente_energy/solar_adapter.py
+++ b/custom_components/vicente_energy/solar_adapter.py
@@ -1,15 +1,21 @@
+"""Adapter that provides solar forecast data to the estimator."""
+
 import logging
 
 _LOGGER = logging.getLogger(__name__)
 
 class SolarForecastAdapter:
+    """Fetch and correct solar forecast data from sensors or services."""
+
     def __init__(self, hass, forecast_entities, state_manager, service_manager=None):
+        """Initialize with Home Assistant objects and configuration."""
         self.hass = hass
         self.state = state_manager
         self.service_manager = service_manager
         self._forecast_entities = list(forecast_entities) if forecast_entities is not None else []
 
     async def get_raw_forecast(self):
+        """Return a list of forecast values from configured sources."""
         raw_forecast = []
         # If an external forecast service is configured, try that first
         if self.service_manager and getattr(self.service_manager, "forecast_service", None):
@@ -40,6 +46,7 @@ class SolarForecastAdapter:
         return raw_forecast
 
     async def get_corrected_forecast(self):
+        """Return forecast adjusted by learned solar bias."""
         raw_forecast = await self.get_raw_forecast()
         bias = self.state.get_solar_bias()
         corrected = [max(f * (1 + bias), 0.0) for f in raw_forecast]


### PR DESCRIPTION
## Summary
- document the Vicente Energy integration modules
- add class and method docstrings across services and sensors
- clarify helper functions in tests

## Testing
- `ruff check .` *(fails: F401 unused imports)*
- `pytest -q` *(fails: command not found)*